### PR TITLE
Allow controller and service to unsubscribe and pause polling the api.

### DIFF
--- a/ChartController.js
+++ b/ChartController.js
@@ -68,7 +68,7 @@ class ChartController {
     this._statsService = statsService;
     this.id = `${type}-${Date.now()}`;
     this.subscription = this.subscription.bind(this);
-    this._statsService.subscribe(this.subscription);
+    this.subscribe();
   }
   /**
    * @returns {boolean} Is the chart loading?
@@ -133,6 +133,18 @@ class ChartController {
    */
   async subscription(data) {
     this.chart = data;
+  }
+  /**
+   * Unsubscribes the chart from the statService.
+   */
+  unsubscribe() {
+    this._statsService.unsubscribe(this.subscription);
+  }
+  /**
+   * Subscribes the chart from the statService.
+   */
+  subscribe() {
+    this._statsService.subscribe(this.subscription);
   }
 }
 export {ChartController};

--- a/StatsService.js
+++ b/StatsService.js
@@ -33,7 +33,6 @@ class StatsService {
     this.poll = poll;
     this.subscribers = new Set();
     this.results = [];
-    this.start();
   }
   /**
    * Determines if this is the first load.
@@ -79,15 +78,20 @@ class StatsService {
    */
   subscribe(subscription) {
     this.subscribers.add(subscription);
+    this.start();
   }
   /**
    * Each subscription is unique and can be deleted.
+   * If there are no subscriptions stop polling the api.
    *
    * @param {Subscription} subscription
    * - This can be a ChartController's subscription function.
    */
   unsubscribe(subscription) {
-    this.subscribers = this.subscribers.delete(subscription);
+    this.subscribers.delete(subscription);
+    if(!this.subscribers.size) {
+      this.stop();
+    }
   }
   /*
    * gets the actual data from the stats rest api

--- a/StatsService.js
+++ b/StatsService.js
@@ -89,7 +89,7 @@ class StatsService {
    */
   unsubscribe(subscription) {
     this.subscribers.delete(subscription);
-    if(!this.subscribers.size) {
+    if(this.subscribers.size === 0) {
       this.stop();
     }
   }

--- a/test/components/Home.vue
+++ b/test/components/Home.vue
@@ -3,6 +3,14 @@
     v-if="!loading"
     class="column gutter-md background"
     padding>
+    <q-btn
+      @click="unsubscribe">
+      Unsubscribe
+    </q-btn>
+    <q-btn
+      @click="subscribe">
+      Subscribe
+    </q-btn>
     <div class="row">
       <span class="col-4">
         <br-gauge-chart
@@ -85,10 +93,14 @@ export default {
       if(!this.cpu) {
         return true;
       }
+      if(!this.cpu.loading) {
+        this.$q.loading.hide();
+      }
       return this.cpu.loading;
     }
   },
   mounted() {
+    this.$q.loading.show();
     this.$set(this, 'cpu', new ChartController(
       {
         type: 'pie',
@@ -145,6 +157,22 @@ export default {
         }}));
   },
   methods: {
+    unsubscribe() {
+      this.diskseries.unsubscribe();
+      this.ramseries.unsubscribe();
+      this.cpuseries.unsubscribe();
+      this.disk.unsubscribe();
+      this.ram.unsubscribe();
+      this.cpu.unsubscribe();
+    },
+    subscribe() {
+      this.diskseries.subscribe();
+      this.ramseries.subscribe();
+      this.cpuseries.subscribe();
+      this.disk.subscribe();
+      this.ram.subscribe();
+      this.cpu.subscribe();
+    },
     colors(alpha = 1) {
       return {
         ram: `rgba(0, 0, 184, ${alpha})`,


### PR DESCRIPTION
ok so what this does is pretty simple
when statsService starts it does not start polling the api.
When an initial subscription is made the polling starts.
When all controllers unsubscribe it stops polling.
this is so the controller and service can work better with components
i.e. when a component is destroyed it's controller can unsubscribe.
in turn the service does not make redundant calls to the api if there are no subscribers.